### PR TITLE
Log invalid promise resolve / reject rather than asserting

### DIFF
--- a/android/src/main/java/io/jari/fingerprint/FingerprintModule.java
+++ b/android/src/main/java/io/jari/fingerprint/FingerprintModule.java
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager;
 import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
 import android.support.v4.os.CancellationSignal;
 import android.support.v4.app.ActivityCompat;
+import android.util.Log;
 
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -144,7 +145,7 @@ public class FingerprintModule extends ReactContextBaseJavaModule {
                 isCancelled = true;
             }
             if(promise == null) {
-                throw new AssertionError("Tried to reject the auth promise, but it was already resolved / rejected. This shouldn't happen.");
+                Log.e("FingerprintModule", "Tried to reject the auth promise, but it was already resolved / rejected. This shouldn't happen.");
             }
             promise.reject(Integer.toString(errorCode), errString.toString());
             promise = null;
@@ -166,7 +167,7 @@ public class FingerprintModule extends ReactContextBaseJavaModule {
         public void onAuthenticationSucceeded(FingerprintManagerCompat.AuthenticationResult result) {
             super.onAuthenticationSucceeded(result);
             if(promise == null) {
-                throw new AssertionError("Tried to resolve the auth promise, but it was already resolved / rejected. This shouldn't happen.");
+                Log.e("FingerprintModule", "Tried to resolve the auth promise, but it was already resolved / rejected. This shouldn't happen.");
             }
             promise.resolve(null);
             promise = null;

--- a/android/src/main/java/io/jari/fingerprint/FingerprintModule.java
+++ b/android/src/main/java/io/jari/fingerprint/FingerprintModule.java
@@ -146,9 +146,10 @@ public class FingerprintModule extends ReactContextBaseJavaModule {
             }
             if(promise == null) {
                 Log.e("FingerprintModule", "Tried to reject the auth promise, but it was already resolved / rejected. This shouldn't happen.");
+            } else {
+                promise.reject(Integer.toString(errorCode), errString.toString());
+                promise = null;
             }
-            promise.reject(Integer.toString(errorCode), errString.toString());
-            promise = null;
         }
 
         @Override
@@ -168,9 +169,10 @@ public class FingerprintModule extends ReactContextBaseJavaModule {
             super.onAuthenticationSucceeded(result);
             if(promise == null) {
                 Log.e("FingerprintModule", "Tried to resolve the auth promise, but it was already resolved / rejected. This shouldn't happen.");
+            } else {
+                promise.resolve(null);
+                promise = null;
             }
-            promise.resolve(null);
-            promise = null;
         }
 
         @Override


### PR DESCRIPTION
As @mgoforth described here: https://github.com/jariz/react-native-fingerprint-android/issues/19

These asserts shouldn't get hit, but in production we're seeing them get hit a fair bit.

This PR just replaces the asserts with logs as suggested.