### PR TITLE
Specify package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,12 @@
     "bugs": {
         "url": "https://github.com/jariz/react-native-fingerprint-android/issues"
     },
-    "homepage": "https://github.com/jariz/react-native-fingerprint-android#readme"
+    "homepage": "https://github.com/jariz/react-native-fingerprint-android#readme",
+    "files": [
+      "android/src",
+      "android/build.gradle"
+      "index.android.js",
+      "index.ios.js",
+      "index.js"
+    ]
 }


### PR DESCRIPTION
The current v0.1.7 release [contains a few unrelated files](https://unpkg.com/react-native-fingerprint-android@0.1.7/), for example, `.gradle/` and `.idea/`. Using [`package.json`’s `files` field](https://docs.npmjs.com/files/package.json#files), we can include only the necessary files.